### PR TITLE
feat(repo): adding conformance test workflow

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -24,11 +24,10 @@ on:
           - major
 
 jobs:
-  # TODO: Uncomment once test is available in released node.
-  #api-equivalence:
-    #uses: ./github/workflows/test-equivalence.yml
-    #with:
-      #GO_VERSION: "1.22"
+  api-equivalence:
+    uses: ./github/workflows/test-equivalence.yml
+    with:
+      GO_VERSION: "1.22"
 
   lint:
     uses: ./.github/workflows/lint.yml

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   api-equivalence:
-    uses: ./github/workflows/test-equivalence.yml
+    uses: ./.github/workflows/test-equivalence.yml
     with:
       GO_VERSION: "1.22"
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -41,7 +41,7 @@ jobs:
 
   # Make a release if this is a manually trigger job, i.e. workflow_dispatch
   release:
-    needs: [lint, test]
+    needs: [lint, test, api-equivalence]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions: "write-all"

--- a/.github/workflows/test-equivalence.yml
+++ b/.github/workflows/test-equivalence.yml
@@ -18,10 +18,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: celestiaorg/node-api-conformance-test
-          ref: v0.13.4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.GO_VERSION }}
 
       - name: Run Structs Equivalence Test
-        run: cd node-api-conformance-test && go test
+        run: go test

--- a/.github/workflows/test-equivalence.yml
+++ b/.github/workflows/test-equivalence.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: celestiaorg/celestia-node
+          repository: celestiaorg/node-api-conformance-test
           ref: v0.13.4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.GO_VERSION }}
 
       - name: Run Structs Equivalence Test
-        run: cd celestia-node && go test -v -tags=conformance ./api -run TestAPIEquivalence
+        run: cd node-api-conformance-test && go test

--- a/.github/workflows/test-equivalence.yml
+++ b/.github/workflows/test-equivalence.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 jobs:
-  test-equivalence:
+  api-equivalence:
     name: Test API Equivalence
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adds the conformance test - node didn't want it in the upstream repo so it has been offloaded to celestiaorg/node-api-conformance-test.

This will likely fail at first, will fix